### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,8 +6,8 @@
         "labeling"
     ],
     "description": "Filter objects and tags by user and copy them to working area",
-    "docker_image": "supervisely/labeling:0.0.5",
-    "instance_version": "6.4.57",
+    "docker_image": "supervisely/labeling:6.73.564",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",
     "task_location": "application_sessions",

--- a/config.json
+++ b/config.json
@@ -1,22 +1,22 @@
 {
-    "name": "Review labels side-by-side",
-    "type": "app",
-    "categories": [
-        "images",
-        "labeling"
-    ],
-    "description": "Filter objects and tags by user and copy them to working area",
-    "docker_image": "supervisely/labeling:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "gui_template": "src/gui.html",
-    "task_location": "application_sessions",
-    "isolate": true,
-    "headless": false,
-    "integrated_into": [
-        "image_annotation_tool"
-    ],
-    "icon": "https://img.icons8.com/color/100/000000/rules-book.png",
-    "icon_background": "#FFFFFF",
-    "poster": "https://user-images.githubusercontent.com/106374579/187885841-690d3d80-557b-4f1d-a421-a254aa2260fd.png"
+  "name": "Review labels side-by-side",
+  "type": "app",
+  "categories": [
+    "images",
+    "labeling"
+  ],
+  "description": "Filter objects and tags by user and copy them to working area",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "gui_template": "src/gui.html",
+  "task_location": "application_sessions",
+  "isolate": true,
+  "headless": false,
+  "integrated_into": [
+    "image_annotation_tool"
+  ],
+  "icon": "https://img.icons8.com/color/100/000000/rules-book.png",
+  "icon_background": "#FFFFFF",
+  "poster": "https://user-images.githubusercontent.com/106374579/187885841-690d3d80-557b-4f1d-a421-a254aa2260fd.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.70
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
